### PR TITLE
Fix a typo in message

### DIFF
--- a/app/elements/arc-settings-controller/arc-settings-controller.html
+++ b/app/elements/arc-settings-controller/arc-settings-controller.html
@@ -201,7 +201,7 @@ the License.
             </paper-input-container>
           </paper-item>
           <p class="single-page-description">
-            When set to "0" (zero) then the request will newer timeout. If the server do not close the connection and send no response then the request will never end.
+            When set to "0" (zero) then the request will never timeout. If the server does not close the connection and sends no response then the request will never end.
           </p>
           <p class="single-page-description">
             Set the value to positive number to set the time (in seconds) after which the request will timeout.


### PR DESCRIPTION
Fixes a small typo in the message.

<img width="1177" alt="screen shot 2016-06-18 at 8 38 39 pm" src="https://cloud.githubusercontent.com/assets/10262447/16175019/b7063f1a-3594-11e6-899f-6718d8b37f02.png">

It should be "request will never timeout" instead of "request will newer timeout".